### PR TITLE
Update to patched version of spring-boot-starter-parent to address Spring4Shell

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.1.RELEASE</version>
+    <version>2.5.12</version>
   </parent>
   <name>petclinic</name>
 
@@ -63,6 +63,10 @@
                 <artifactId>junit-vintage-engine</artifactId>
             </exclusion>
         </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
     <!-- Databases - Uses HSQL by default -->


### PR DESCRIPTION
`Spring4Shell` is a vulnerability that was recently disclosed:

- https://nvd.nist.gov/vuln/detail/CVE-2022-22965
- https://spring.io/blog/2022/04/01/spring-framework-rce-mitigation-alternative

This PR updates `spring-boot-starter-parent` to a patched version.